### PR TITLE
Add 'layout_above' attribute to anchor ViewPager fragments.

### DIFF
--- a/library/src/main/res/layout/intro_layout.xml
+++ b/library/src/main/res/layout/intro_layout.xml
@@ -9,7 +9,8 @@
     <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/bottom" />
 
     <LinearLayout
         android:id="@+id/bottom"

--- a/library/src/main/res/layout/intro_layout2.xml
+++ b/library/src/main/res/layout/intro_layout2.xml
@@ -14,7 +14,8 @@
     <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/bottom" />
 
     <LinearLayout
         android:id="@+id/bottom"


### PR DESCRIPTION
Avoid overlapping views in cases where the added
Fragments merge with the bottom layout.