### PR TITLE
Avoid title from appearing behind statusbar by using fitsSystemWindows

### DIFF
--- a/library/src/main/res/layout/intro_layout.xml
+++ b/library/src/main/res/layout/intro_layout.xml
@@ -8,6 +8,7 @@
 
     <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
+        android:fitsSystemWindows="true"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content" />
 

--- a/library/src/main/res/layout/intro_layout2.xml
+++ b/library/src/main/res/layout/intro_layout2.xml
@@ -13,6 +13,7 @@
 
     <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
+        android:fitsSystemWindows="true"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content" />
 


### PR DESCRIPTION
The title of each slide appeared behind Android statusbar when using statusbar transparency