### PR TITLE
Feature: replace fill_parent with match_parent

### DIFF
--- a/example/src/main/res/layout/tab_custom_background_intro.xml
+++ b/example/src/main/res/layout/tab_custom_background_intro.xml
@@ -8,7 +8,7 @@
     <TextView
         android:id="@+id/tv"
         android:paddingBottom="5dp"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/custom_background_intro"
         android:textSize="18sp" />

--- a/example/src/main/res/layout/tab_custom_layout_intro.xml
+++ b/example/src/main/res/layout/tab_custom_layout_intro.xml
@@ -8,7 +8,7 @@
     <TextView
         android:id="@+id/tv"
         android:paddingBottom="5dp"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/custom_layout_intro"
         android:textSize="18sp" />

--- a/example/src/main/res/layout/tab_default_intro.xml
+++ b/example/src/main/res/layout/tab_default_intro.xml
@@ -8,7 +8,7 @@
     <TextView
         android:id="@+id/tv"
         android:paddingBottom="5dp"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/default_intro"
         android:textSize="18sp" />

--- a/example/src/main/res/layout/tab_default_intro2.xml
+++ b/example/src/main/res/layout/tab_default_intro2.xml
@@ -8,7 +8,7 @@
     <TextView
         android:id="@+id/tv"
         android:paddingBottom="5dp"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/default_intro2"
         android:textSize="18sp" />

--- a/example/src/main/res/layout/tab_permissions_1.xml
+++ b/example/src/main/res/layout/tab_permissions_1.xml
@@ -8,7 +8,7 @@
     <TextView
         android:id="@+id/tv"
         android:paddingBottom="5dp"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/perms_intro1"
         android:textSize="18sp" />

--- a/example/src/main/res/layout/tab_permissions_2.xml
+++ b/example/src/main/res/layout/tab_permissions_2.xml
@@ -8,7 +8,7 @@
     <TextView
         android:id="@+id/tv"
         android:paddingBottom="5dp"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/perms_intro2"
         android:textSize="18sp" />

--- a/example/src/main/res/layout/util_drawer_hdr.xml
+++ b/example/src/main/res/layout/util_drawer_hdr.xml
@@ -4,7 +4,7 @@
     android:layout_height="wrap_content">
 
     <ImageView
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="175dp"
         android:scaleType="centerCrop"
         android:padding="0dp"

--- a/library/src/main/res/layout/default_indicator.xml
+++ b/library/src/main/res/layout/default_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
-    android:layout_height="fill_parent"
+    android:layout_height="match_parent"
     android:layout_gravity="center"
     android:gravity="center"
     android:orientation="horizontal" />

--- a/library/src/main/res/layout/fragment_intro_content.xml
+++ b/library/src/main/res/layout/fragment_intro_content.xml
@@ -17,7 +17,7 @@
         android:textStyle="bold" />
 
     <LinearLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="5"
         android:gravity="center"
@@ -34,7 +34,7 @@
     </LinearLayout>
 
     <LinearLayout
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="3"
         android:gravity="center_horizontal"

--- a/library/src/main/res/layout/intro_layout.xml
+++ b/library/src/main/res/layout/intro_layout.xml
@@ -2,14 +2,14 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="#222222">
 
     <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
         android:fitsSystemWindows="true"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <LinearLayout
@@ -23,19 +23,19 @@
 
         <TextView
             android:id="@+id/bottom_separator"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="1px"
             android:background="#55000000" />
 
         <FrameLayout
             android:id="@+id/bottomContainer"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
             <FrameLayout
                 android:id="@+id/indicator_container"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_gravity="center"
                 android:layoutDirection="ltr"/>
 
@@ -43,7 +43,7 @@
                 android:id="@+id/skip"
                 style="@style/AppIntroButtonStyleCompat"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_gravity="start"
                 android:layout_marginLeft="8dp"
                 android:layout_marginStart="8dp"
@@ -55,7 +55,7 @@
                 android:id="@+id/back"
                 style="@style/AppIntroButtonStyleCompat"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_gravity="start"
                 android:layout_marginLeft="8dp"
                 android:layout_marginStart="8dp"
@@ -68,7 +68,7 @@
                 android:id="@+id/next"
                 style="@style/AppIntroButtonStyleCompat"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_gravity="end"
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
@@ -80,7 +80,7 @@
                 android:id="@+id/done"
                 style="@style/AppIntroButtonStyleCompat"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_gravity="end"
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"

--- a/library/src/main/res/layout/intro_layout2.xml
+++ b/library/src/main/res/layout/intro_layout2.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="fill_parent"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="#222222">
 
@@ -14,7 +14,7 @@
     <com.github.paolorotolo.appintro.AppIntroViewPager
         android:id="@+id/view_pager"
         android:fitsSystemWindows="true"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <LinearLayout
@@ -28,20 +28,20 @@
 
         <TextView
             android:id="@+id/bottom_separator"
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="1px"
             android:background="#55000000"
             android:visibility="gone" />
 
         <FrameLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp">
 
             <FrameLayout
                 android:id="@+id/indicator_container"
                 android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_height="match_parent"
                 android:layout_gravity="center"
                 android:layoutDirection="ltr" />
 


### PR DESCRIPTION
This pull request closes #481 by replacing all occurrences of "fill_parent" with "match_parent".

Since the specified minimum SDK version is 14 (for both the example and the library module) it's safe to do that because it's higher than SDK version 8 where "match_parent" was introduced.