### PR TITLE
Fixed redundant and wrong calls to onUserIllegallyRequestedNextPage method

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ apply from: 'maven-push.gradle'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 14

--- a/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
+++ b/library/src/main/java/com/github/paolorotolo/appintro/AppIntroViewPager.java
@@ -88,6 +88,11 @@ public final class AppIntroViewPager extends ViewPager {
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent event) {
+        // If paging is disabled we should ignore any viewpager touch (also, not display any error message)
+        if (!pagingEnabled) {
+            return false;
+        }
+
         if (event.getAction() == MotionEvent.ACTION_DOWN) {
             currentTouchDownX = event.getX();
             return super.onInterceptTouchEvent(event);
@@ -102,10 +107,16 @@ public final class AppIntroViewPager extends ViewPager {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        // If paging is disabled we should ignore any viewpager touch (also, not display any error message)
+        if (!pagingEnabled) {
+            return false;
+        }
+
         if (event.getAction() == MotionEvent.ACTION_DOWN) {
             currentTouchDownX = event.getX();
             return super.onTouchEvent(event);
         }
+
         // Check if we should handle the touch event
         else if (checkPagingState(event) || checkCanRequestNextPage(event)) {
             // Call callback method if threshold has been reached
@@ -117,10 +128,6 @@ public final class AppIntroViewPager extends ViewPager {
     }
 
     private boolean checkPagingState(MotionEvent event) {
-        if (!pagingEnabled) {
-            return true;
-        }
-
         if (!nextPagingEnabled) {
             if (event.getAction() == MotionEvent.ACTION_DOWN) {
                 currentTouchDownX = event.getX();


### PR DESCRIPTION
Hello,

I've fixed some problematic code logic in the `AppIntroViewPager`.
Whenever the view pager is in "lock" mode (for instance when the intro uses permission slides),
any touch on the `viewpager `should be totally ignored, means it should not even call `onUserIllegallyRequestedNextPage` as it does now.

For any further questions, I will be happy to explain.