### PR TITLE
Added missing accessibility labels for all the buttons #565

### DIFF
--- a/library/src/main/res/layout/intro_layout.xml
+++ b/library/src/main/res/layout/intro_layout.xml
@@ -48,6 +48,7 @@
                 android:layout_marginLeft="8dp"
                 android:layout_marginStart="8dp"
                 android:minWidth="100dp"
+                android:labelFor="@string/app_intro_skip_button"
                 android:text="@string/app_intro_skip_button"
                 android:textColor="@android:color/white" />
 
@@ -85,6 +86,7 @@
                 android:layout_marginEnd="8dp"
                 android:layout_marginRight="8dp"
                 android:minWidth="100dp"
+                android:labelFor="@string/app_intro_done_button"
                 android:text="@string/app_intro_done_button"
                 android:textColor="@android:color/white"
                 android:visibility="gone" />

--- a/library/src/main/res/layout/intro_layout2.xml
+++ b/library/src/main/res/layout/intro_layout2.xml
@@ -53,6 +53,7 @@
                 android:layout_gravity="start"
                 android:layout_marginLeft="16dp"
                 android:layout_marginStart="16dp"
+                android:contentDescription="@string/app_intro_skip_button"
                 app:srcCompat="@drawable/ic_skip_white"
                 tools:ignore="ContentDescription" />
 
@@ -65,6 +66,7 @@
                 android:layout_marginLeft="16dp"
                 android:layout_marginStart="16dp"
                 android:visibility="invisible"
+                android:contentDescription="@string/app_intro_back_button"
                 app:srcCompat="@drawable/ic_arrow_back_white"
                 tools:ignore="ContentDescription" />
 
@@ -76,6 +78,7 @@
                 android:layout_gravity="end"
                 android:layout_marginEnd="16dp"
                 android:layout_marginRight="16dp"
+                android:contentDescription="@string/app_intro_next_button"
                 app:srcCompat="@drawable/ic_arrow_forward_white"
                 tools:ignore="ContentDescription" />
 
@@ -88,6 +91,7 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginRight="16dp"
                 android:visibility="gone"
+                android:contentDescription="@string/app_intro_done_button"
                 app:srcCompat="@drawable/ic_done_white"
                 tools:ignore="ContentDescription" />
         </FrameLayout>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_intro_skip_button">SKIP</string>
+    <string name="app_intro_next_button" tools:ignore="MissingTranslation">NEXT</string>
+    <string name="app_intro_back_button" tools:ignore="MissingTranslation">BACK</string>
     <string name="app_intro_done_button">DONE</string>
 </resources>


### PR DESCRIPTION
Fix for #565 

Unfortunately we need to translate two more strings to all the supported languages. Don't really know how we do that? Should we just fallback to `en` for accessibility?