### PR TITLE
Fix for titleString & descriptionString in the SliderPage

### DIFF
--- a/library/src/main/java/com/github/paolorotolo/appintro/model/SliderPage.kt
+++ b/library/src/main/java/com/github/paolorotolo/appintro/model/SliderPage.kt
@@ -16,6 +16,6 @@ data class SliderPage @JvmOverloads constructor(
         var titleTypeface: String? = null,
         var descTypeface: String? = null
 ) {
-    val titleString = title?.toString()
-    val descriptionString = description?.toString()
+    val titleString : String? get() = title?.toString()
+    val descriptionString : String? get() = description?.toString()
 }


### PR DESCRIPTION
Looks like a broke two fields of `SliderPage` when I converted it to Kotlin 😅

both `titleString` and `descriptionString` should not have a backing field.
We want those properties to behave as getters and do not have an associated value.

The current implementation was causing several titles to disappear:
![screenshot_1535578033](https://user-images.githubusercontent.com/3001957/44816656-29157c80-abe3-11e8-95b4-2b89eccbc30a.png)
